### PR TITLE
Various fixes to setup.py for Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,12 @@ DATA_FILES = []
 PLIST = {   "CFBundleDocumentTypes": [ { "CFBundleTypeExtensions": ["hdf5","h5"],
                                       "CFBundleTypeName": "HDF5 Data File",
                                       "CFBundleTypeRole": "Viewer"} ],
-            "CFBundleIdentifer": "org.alfven.hdfcompass",
+            "CFBundleIdentifer": "org.hdfgroup.compass",
             "CFBundleDisplayName": "HDFCompass",
-            "CFBundleVersion": "0.4.0" }
+            "CFBundleVersion": "0.5.0" }
 
 OPTIONS = { 'argv_emulation': True,
-            'excludes': ['scipy'],
+            'excludes': ['scipy', 'PyQt4', 'mpi4py'],
             'matplotlib_backends': ['wxagg'],
             'iconfile': 'compass.icns',
             'plist': PLIST }


### PR DESCRIPTION
This updates a couple of things for building on Mac:

1. Changes the BundleID to put it in the HDF Group namespace.  It's important to do this before general release because it's involved in file associations on the Mac.
2. Update the version so OS X displays it correctly in the about box.
3. Specifically exclude some extraneous imports that increase the size of the app (PyQT is also non-BSD so we should avoid distributing it by mistake.)