### PR TITLE
Basic README for github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-hdf-compass
+HDF Compass
 ===========
+
+Welcome to the project!  HDF Compass is an experimental viewer program for
+HDF5 and related formats, designed to complement other more complex
+applications like HDFView.  Strong emphasis is placed on clean minimal design,
+and maximum extensibility through a plugin system for new formats.
+
+HDF Compass is written in Python, but ships as a native application on
+Windows, OS X, and Linux, by using PyInstaller and Py2App to package the app.
+
+Bug reports and pull requests are welcome!  For non-trivial PRs please
+open an issue first, so the core developers can give feedback on your idea.
+
+Development Environment
+-----------------------
+
+You will need:
+
+* Python 2.7
+* NumPy
+* Matplotlib
+* wxPython Phoenix (2.9.5.0 or later)
+* h5py
+
+For packaging the app:
+
+* Py2App (OS X)
+* PyInstaller (Linux & Windows)
+
+Running the Program
+-------------------
+
+    $ python HDFCompass.py
+    
+Packaging on OS X
+-----------------
+
+    $ python setup.py py2app
+    
+Packaging on Windows
+--------------------
+
+    $ pyinstaller HDFCompass.spec
+    
+Other info
+----------
+
+* Homepage: http://github.com/HDFGroup/hdf-compass
+* License: BSD-like HDF Group license (See COPYING)


### PR DESCRIPTION
Add a simple README file with requirements and info for interested developers.  This is shown by default on the GitHub project page.