### PR TITLE
Adjust HDF5 cache settings

### DIFF
--- a/hdf5_model/__init__.py
+++ b/hdf5_model/__init__.py
@@ -45,7 +45,7 @@ class HDF5Store(compass_model.Store):
 
     file_extensions = {'HDF5 File': ['*.hdf5', '*.h5']}
     
-    CACHE_NCHUNKS = 100         # Cache at most this many chunks per dataset
+    CACHE_NSLOTS = 521          # Cache tuning parameter; see HDF5 docs
     CACHE_NBYTES = int(25e6)    # Cache at most this many bytes per dataset
     
     def __contains__(self, key):
@@ -91,7 +91,7 @@ class HDF5Store(compass_model.Store):
         fapl = h5py.h5p.create(h5py.h5p.FILE_ACCESS)
         # First argument is ignored by HDF5.
         # Last argument adjusts the preemption policy (0.0 = simple LRU)
-        fapl.set_cache(0, self.CACHE_NCHUNKS, self.CACHE_NBYTES, 0.0)
+        fapl.set_cache(0, self.CACHE_NSLOTS, self.CACHE_NBYTES, 0.0)
         fid = h5py.h5f.open(path, h5py.h5f.ACC_RDONLY, fapl=fapl)
         self.f = h5py.File(fid)
 


### PR DESCRIPTION
An example PR which addresses #32 by adjusting the default caching strategy for datasets.

Limits the maximum cache size per dataset to 25 MB, and at most 100 chunks.  These numbers could be adjusted in the future based on user feedback.

Rather annoying that h5py does not provide a top-level keyword argument for cache adjustment.