### PR TITLE
Fix typo in context menu code

### DIFF
--- a/compass_viewer/container/list.py
+++ b/compass_viewer/container/list.py
@@ -134,7 +134,7 @@ class ContainerList(wx.ListCtrl):
         Posts an event requesting that the node be opened as-is.
         """
         pos = wx.GetTopLevelParent(self).GetPosition()
-        wx.PostEvent(self, CompassOpenEvent(self._menu_node), pos=pos)
+        wx.PostEvent(self, CompassOpenEvent(self._menu_node, pos=pos))
 
 
     def on_context_openwindow(self, evt):


### PR DESCRIPTION
Address context menu "open" not working (#34).