### PR TITLE
Implement tile caching directly at the GridTable level

### DIFF
--- a/hdf5_model/__init__.py
+++ b/hdf5_model/__init__.py
@@ -44,9 +44,7 @@ class HDF5Store(compass_model.Store):
     """
 
     file_extensions = {'HDF5 File': ['*.hdf5', '*.h5']}
-    
-    CACHE_NSLOTS = 521          # Cache tuning parameter; see HDF5 docs
-    CACHE_NBYTES = int(25e6)    # Cache at most this many bytes per dataset
+
     
     def __contains__(self, key):
         return key in self.f
@@ -87,14 +85,8 @@ class HDF5Store(compass_model.Store):
             raise ValueError(url)
         self._url = url
         path = url.replace('file://','')
+        self.f = h5py.File(path, 'r')
         
-        fapl = h5py.h5p.create(h5py.h5p.FILE_ACCESS)
-        # First argument is ignored by HDF5.
-        # Last argument adjusts the preemption policy (0.0 = simple LRU)
-        fapl.set_cache(0, self.CACHE_NSLOTS, self.CACHE_NBYTES, 0.0)
-        fid = h5py.h5f.open(path, h5py.h5f.ACC_RDONLY, fapl=fapl)
-        self.f = h5py.File(fid)
-
     def close(self):
         self.f.close()
 


### PR DESCRIPTION
Inspired by #35, adds a tile-based LRU cache within the Array viewer.  Should work transparently with anything that implements the Array interface, including HDF5 but also things like DAP, etc.

Uses the same (100,) or (100,100) tile shape as #35.  Tested with both problem files from #32 and #35.