### PR TITLE
fix Mac icon file name to match rename from da5f6f4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ OPTIONS = { 'argv_emulation': False,
             'excludes': ['scipy', 'PyQt4', 'mpi4py'],
             'includes': ['h5py', 'matplotlib'],
             'matplotlib_backends': ['wxagg',],
-            'iconfile': 'compass.icns',
+            'iconfile': 'HDFCompass.icns',
             'packages': ['h5py', 'matplotlib'],
             'plist': PLIST }
 


### PR DESCRIPTION
compass.icns was renamed to HDFCompass.icns.