### PR TITLE
py3k: Add __future__ import on remaining files.

### DIFF
--- a/data/hdf5/Download/download_data.py
+++ b/data/hdf5/Download/download_data.py
@@ -1,7 +1,10 @@
-import wget
 """
 Download additional data files from AWS
 """
+
+from __future__ import absolute_import, division, print_function
+
+import wget
 
 files = [
    'ami_hdf.h5',
@@ -27,5 +30,3 @@ for filename in files:
     print("downloading: " + uri)
     wget.download(uri, bar=wget.bar_thermometer)
 print("done!")
-    
-    

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import, division, print_function
+
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/hdf_compass/__init__.py
+++ b/hdf_compass/__init__.py
@@ -1,6 +1,7 @@
 """
 HDFCompass Namespace
 """
+from __future__ import absolute_import, division, print_function
 try:
     import pkg_resources
     pkg_resources.declare_namespace(__name__)

--- a/hdf_compass/compass_model/test.py
+++ b/hdf_compass/compass_model/test.py
@@ -41,6 +41,8 @@ To run unittest, which discovers classes "store_tests" and "container_tests":
 
 """
 
+from __future__ import absolute_import, division, print_function
+
 import unittest as ut
 
 from . import Node, Store

--- a/hdf_compass/filesystem_model/test.py
+++ b/hdf_compass/filesystem_model/test.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from hdf_compass.compass_model.test import container, store
 from hdf_compass.filesystem_model import Filesystem, Directory
 

--- a/hdf_compass/hdf5_model/test.py
+++ b/hdf_compass/hdf5_model/test.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from hdf_compass.compass_model.test import container, store
 from hdf_compass.hdf5_model import HDF5Group, HDF5Store
 from hdf_compass.utils import is_win

--- a/setup.py2app.py
+++ b/setup.py2app.py
@@ -27,6 +27,8 @@ To create dmg install file.  The appdmg utility can be installed from npm:
 PyInstaller, for Windows and Linux distribution, does not use setup.py2app.py.
 """
 
+from __future__ import absolute_import, division, print_function
+
 from setuptools import setup
 from glob import glob
 import os


### PR DESCRIPTION
Though this was mostly done in #64, a few files are missing these imports. Even though there are no print statements, it is best to do the import in case any are introduced in the future.