### PR TITLE
add notebook to visualize plugin info

### DIFF
--- a/hdf_compass/array_model/model.py
+++ b/hdf_compass/array_model/model.py
@@ -55,6 +55,14 @@ class ArrayStore(compass_model.Store):
         Keys are array names as reported in DATA.
     """
 
+    @staticmethod
+    def plugin_name():
+        return "Array"
+
+    @staticmethod
+    def plugin_description():
+        return "A testing plugin used to evaluate the array visualization."
+
     def __contains__(self, key):
         if (key == '/') or (key is None):
             log.debug("is root: %s" % key)

--- a/hdf_compass/asc_model/model.py
+++ b/hdf_compass/asc_model/model.py
@@ -34,6 +34,14 @@ from hdf_compass.utils import url2path
 class AsciiGrid(compass_model.Store):
     """ A "data store" represented by an ascii grid file. """
 
+    @staticmethod
+    def plugin_name():
+        return "Ascii Grid"
+
+    @staticmethod
+    def plugin_description():
+        return "A plugin used to browse Ascii Grid."
+
     file_extensions = {'ASC File': ['*.asc']}
 
     def __contains__(self, key):

--- a/hdf_compass/bag_model/model.py
+++ b/hdf_compass/bag_model/model.py
@@ -45,6 +45,14 @@ class BAGStore(compass_model.Store):
 
     Keys are the full names of objects in the file.
     """
+    @staticmethod
+    def plugin_name():
+        return "BAG"
+
+    @staticmethod
+    def plugin_description():
+        return "A plugin used to browse Open Navigation Surface BAG files."
+
     file_extensions = {'BAG File': ['*.bag']}
 
     def __contains__(self, key):

--- a/hdf_compass/compass_model/model.py
+++ b/hdf_compass/compass_model/model.py
@@ -105,6 +105,19 @@ class Store(object):
 
     __nodeclasses = None
 
+    @staticmethod
+    def plugin_name():
+        """ Short name for the plugin. """
+        raise NotImplementedError
+
+    @staticmethod
+    def plugin_description():
+        """ Plugin description.
+
+        Return useful info about the plugin as the main functionalities, the author, the support email (if any)
+        """
+        raise NotImplementedError
+
     @classmethod
     def push(cls, nodeclass):
         """ Register a Node subclass.

--- a/hdf_compass/filesystem_model/model.py
+++ b/hdf_compass/filesystem_model/model.py
@@ -36,6 +36,14 @@ class Filesystem(compass_model.Store):
         Keys are absolute paths on the local file system.
     """
 
+    @staticmethod
+    def plugin_name():
+        return "Filesystem"
+
+    @staticmethod
+    def plugin_description():
+        return "A plugin used to browse local files and folders."
+
     def __contains__(self, key):
         return op.exists(key)
 

--- a/hdf_compass/hdf5_model/model.py
+++ b/hdf_compass/hdf5_model/model.py
@@ -45,6 +45,13 @@ class HDF5Store(compass_model.Store):
 
     Keys are the full names of objects in the file.
     """
+    @staticmethod
+    def plugin_name():
+        return "HDF5"
+
+    @staticmethod
+    def plugin_description():
+        return "A plugin used to browse HDF5 files."
 
     file_extensions = {'HDF5 File': ['*.hdf5', '*.h5']}
 

--- a/hdf_compass/hdf5rest_model/model.py
+++ b/hdf_compass/hdf5rest_model/model.py
@@ -33,6 +33,7 @@ from hdf_compass.utils import url2path
 
 from . import hdf5dtype
 
+
 def get_json(endpoint, domain=None, uri=None):
                
     # try to do a GET from the domain
@@ -54,7 +55,8 @@ def get_json(endpoint, domain=None, uri=None):
     rsp_json = json.loads(rsp.text)
                     
     return rsp_json
-    
+
+
 def sort_key(name):
     """ Sorting key for names in an HDF5 group.
 
@@ -78,6 +80,13 @@ class HDF5RestStore(compass_model.Store):
             /datasets/<uuid>
             /datatypes/<uuid>
     """
+    @staticmethod
+    def plugin_name():
+        return "HDF5 Rest"
+
+    @staticmethod
+    def plugin_description():
+        return "A plugin used to access HDF Services."
 
     def __contains__(self, key):
         if key in self.f:

--- a/hdf_compass/opendap_model/model.py
+++ b/hdf_compass/opendap_model/model.py
@@ -34,6 +34,13 @@ def check_key(key, dataset):
 
 class Server(compass_model.Store):
     """ Represents the remote OpENDAP server to be accessed """
+    @staticmethod
+    def plugin_name():
+        return "OpENDAP"
+
+    @staticmethod
+    def plugin_description():
+        return "A plugin used to access OpENDAP Servers."
 
     def __contains__(self, key):
         if '/' not in key:


### PR DESCRIPTION
first implementation for https://github.com/HDFGroup/hdf-compass/issues/73
it modifies the ``compass_model`` by adding 2 static methods:

* ``plugin_name``
* ``plugin_description``