### PR TITLE
Loosen versioned dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup_args['keywords'] = "data hdf bag ascii grid opendap"
 # requirements
 setup_args['setup_requires'] =\
     [
-        "setuptools==19.2",
+        "setuptools",
         "wheel",
     ]
 setup_args['install_requires'] =\


### PR DESCRIPTION
We should not require such strict versioned dependencies for setuptools and wxpython. Changing to minimum versions rather than strict ones.