### PR TITLE
Add .desktop file for freedesktop compliant systems.

### DIFF
--- a/HDFCompass.desktop
+++ b/HDFCompass.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=HDFCompass
+GenericName=HDFCompass
+Comment=Viewer program for HDF5 and related formats
+TryExec=HDFCompass
+Exec=HDFCompass %f
+Categories=Development;Science;
+Keywords=Python;HDF;science;viewer;
+Icon=HDFCompass
+Terminal=false
+StartupNotify=true
+MimeType=text/x-python;


### PR DESCRIPTION
I am providing a generic desktop file for HDFCompass, which will be useful for discovering the application on any UNIX distribution complying with the freedesktop standard.