### PR TITLE
Fix missing end quotes in inline literal.

### DIFF
--- a/docs/data_model.rst
+++ b/docs/data_model.rst
@@ -252,7 +252,7 @@ Arrays
 .. method:: Array.__getitem__(indices)
 
     Retrieve data from the array, using the standard array-slicing syntax
-    ``data = array[idx1, idx2, idx3].  *indices* are the slicing arguments.
+    ``data = array[idx1, idx2, idx3]``.  *indices* are the slicing arguments.
     Only integer indexes and slice objects (representing ranges) are
     supported.
 


### PR DESCRIPTION
Running `sphinx-build` produces the following warning:

```
hdf-compass/docs/data_model.rst:254: WARNING: Inline literal start-string without end-string.
```

This PR closes the inline literal with the missing back quotes. 
