### PR TITLE
Feature: Save Directory in Open-Dialog

### DIFF
--- a/hdf_compass/compass_viewer/frame.py
+++ b/hdf_compass/compass_viewer/frame.py
@@ -61,6 +61,8 @@ class BaseFrame(wx.Frame):
     icon_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), 'icons'))
     open_frames = 0  # count the number of frames
 
+    last_open_path = os.getcwd()
+
     def __init__(self, **kwds):
         """ Constructor; any keywords are passed on to wx.Frame.
         """
@@ -190,10 +192,12 @@ class BaseFrame(wx.Frame):
             
         wc_string = make_filter_string()
         
-        dlg = wx.FileDialog(self, "Open Local File", wildcard=wc_string, style=wx.FD_OPEN|wx.FD_FILE_MUST_EXIST)
+        dlg = wx.FileDialog(self, "Open Local File", wildcard=wc_string, defaultDir=BaseFrame.last_open_path, style=wx.FD_OPEN|wx.FD_FILE_MUST_EXIST)
         if dlg.ShowModal() != wx.ID_OK:
             return
         path = dlg.GetPath()
+
+        BaseFrame.last_open_path = os.path.dirname(path)
 
         url = path2url(path)
         self.open_url(url)


### PR DESCRIPTION
Save the last directory when browsing in the open file dialog. This helps to avoid browsing long paths every time.

I'm aware there is a `wx.FD_CHANGE_DIR` flag for the `wx.FileDialog`, but I preferred to store the path in a string and set the directory with `defaultDir` to store separate paths for different dialogs (open, export, ..)
