### PR TITLE
bug (dirty) fix so that hdf_compass[OpenDAP] now requires pydap < 3.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ You will need:
 * `Cartopy <https://github.com/SciTools/cartopy>`_
 * `h5py <https://github.com/h5py/h5py>`_ *[HDF plugin]*
 * `hydroffice.bag <https://bitbucket.org/ccomjhc/hyo_bag>`_ *[BAG plugin]*
-* `Pydap <https://github.com/robertodealmeida/pydap>`_ *[OPeNDAP plugin]*
+* `Pydap <https://github.com/robertodealmeida/pydap>`_ *[OPeNDAP plugin]* (<3.2)
 * `Requests <https://github.com/kennethreitz/requests>`_ *[HDF Rest API plugin]*
 * `adios <https://github.com/ornladios/ADIOS>`_ *[ADIOS Plugin]* (Linux/OSX only)
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ setup_args['extras_require'] =\
     {
         "GeoNodes": ["cartopy[plotting]", ],  # required for visualization of GeoArray and GeoSurface nodes
         "BAG": ["hydroffice.bag>=0.2.10", ],  # required by BAG plugin
-        "OpenDAP": ["pydap", ],  # required by OpenDAP plugin
+        "OpenDAP": ["pydap<3.2", ],  # required by OpenDAP plugin, there is an issue
+                                     # with pydap 3.2: https://github.com/pydap/pydap/issues/66
         "ADIOS": ["adios>=1.9.1b19", ],  # required by ADIOS plugin
     }
 # hdf_compass namespace, packages and other files


### PR DESCRIPTION
ticket: https://github.com/HDFGroup/hdf-compass/issues/60 
pydap issue:  https://github.com/pydap/pydap/issues/66 