### PR TITLE
Fix travis badge URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,13 @@ before_install:
   # Set the anaconda environment
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "$PYTHON_VERSION" == "2.7" ]]; then
-        curl https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh;
+        curl https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -o miniconda.sh;
       else
         curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh;
       fi
     else
       if [[ "$PYTHON_VERSION" == "2.7" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+        wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
       else
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
       fi

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ HDF Compass
     :target: https://ci.appveyor.com/project/giumas/hdf-compass
     :alt: AppVeyor Status
 
-.. image:: https://travis-ci.org/giumas/hdf-compass.svg?branch=develop
-    :target: https://travis-ci.org/giumas/hdf-compass
+.. image:: https://travis-ci.org/HDFGroup/hdf-compass.svg?branch=develop
+    :target: https://travis-ci.org/HDFGroup/hdf-compass
     :alt: Travis-CI Status
         
 Welcome to the project!  HDF Compass is an experimental viewer program for


### PR DESCRIPTION
Travis badge url was pointing to giumas's fork.

Is appveyor still used, should it be removed?