### PR TITLE
ADIOS Backend: Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ os:
   - osx
 
 env:
-#  global:
-#    - ADIOS_ROOT: $HOME/.cache/adios
+  global:
+    - ADIOS_ROOT: $HOME/.cache/adios
   matrix:
     - PYTHON_VERSION=3.6
 
 cache:
   apt: true
   brew: true
-#  directories:
-#    - $HOME/.cache/adios
+  directories:
+    - $HOME/.cache/adios
 
 before_install:
   # Set the anaconda environment
@@ -49,20 +49,20 @@ before_install:
   - source activate test-environment
 
 install:
-#  # ADIOS C library
-#  - export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
-#  - export PATH=$ADIOS_ROOT/bin:$PATH
-#  - ADIOS_FOUND=$(which adios_config >/dev/null && { echo 0; } || { echo 1; })
-#  - if [ $ADIOS_FOUND -ne 0 ]; then
-#      mkdir -p $ADIOS_ROOT &&
-#      travis_retry git clone --depth=50 --branch=master https://github.com/ornladios/ADIOS.git $ADIOS_ROOT/src &&
-#      cd $ADIOS_ROOT/src &&
-#      ./autogen.sh &&
-#      CFLAGS="-fPIC -g" ./configure --enable-static --disable-shared --prefix=$ADIOS_ROOT --with-mxml=/usr --with-zlib=/usr --disable-fortran --without-mpi &&
-#      make && make install &&
-#      cd - &&
-#      rm -rf $ADIOS_ROOT/src;
-#    fi
+  # ADIOS C library
+  - export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
+  - export PATH=$ADIOS_ROOT/bin:$PATH
+  - ADIOS_FOUND=$(which adios_config >/dev/null && { echo 0; } || { echo 1; })
+  - if [ $ADIOS_FOUND -ne 0 ]; then
+      mkdir -p $ADIOS_ROOT &&
+      travis_retry git clone --depth=50 --branch=v1.13.0 https://github.com/ornladios/ADIOS.git $ADIOS_ROOT/src &&
+      cd $ADIOS_ROOT/src &&
+      ./autogen.sh &&
+      CFLAGS="-fPIC -g" ./configure --enable-static --disable-shared --prefix=$ADIOS_ROOT --with-mxml=/usr --with-zlib=/usr --disable-fortran --without-mpi &&
+      make && make install &&
+      cd - &&
+      rm -rf $ADIOS_ROOT/src;
+    fi
   # other libraries
   - conda config --add channels conda-forge
   # python packages
@@ -73,7 +73,7 @@ install:
     else
         pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython;
     fi
-#  - pip install --no-deps 'git+https://github.com/ornladios/ADIOS.git#egg=adios&subdirectory=wrappers/numpy'
+  - pip install --no-deps 'git+https://github.com/ornladios/ADIOS.git@v1.13.0#egg=adios&subdirectory=wrappers/numpy'
   - pip install --no-deps -e .
 
 script:
@@ -83,7 +83,7 @@ script:
   - "python -m unittest hdf_compass.filesystem_model.test"
 #  - "python -m unittest hdf_compass.hdf5_model.test"
 #  - "python -m unittest hdf_compass.opendap_model.test"
-#  - "python -m unittest hdf_compass.adios_model.test"
+  - "python -m unittest hdf_compass.adios_model.test"
 
 after_script:
   # If tests are successful, create a source distribution.

--- a/hdf_compass/adios_model/model.py
+++ b/hdf_compass/adios_model/model.py
@@ -19,7 +19,6 @@ from itertools import groupby
 import sys
 import os.path as op
 import posixpath as pp
-import six
 
 import adios
 
@@ -52,14 +51,10 @@ class ADIOSStore(compass_model.Store):
         if(self.valid):
             if(not key.startswith("/") and key != ""):
                 key = "/%s" % key
-            if six.PY2:
-                key = key.encode("ascii")
             keylist = self.f.var.keys()
             for k in keylist:
                 if(not k.startswith("/") and k != ""):
                     k = "/%s" % k
-                if six.PY2:
-                    k = k.encode("ascii")
                 if(k.startswith(key)):
                     return True
         return False
@@ -93,11 +88,8 @@ class ADIOSStore(compass_model.Store):
         return True
 
     def __init__(self, url):
-        #try:
         self._url = url
         path = url2path(url)
-        if six.PY2:
-            path = path.encode("ascii")
         try:
             self.f = adios.file(path)
             self._valid = True
@@ -131,10 +123,7 @@ class ADIOSGroup(compass_model.Container):
 
     @staticmethod
     def can_handle(store, key):
-        if six.PY2:
-            return (key in store and isinstance(store.f[key.encode("ascii")], adios.group))
-        else:
-            return (key in store and isinstance(store.f[key], adios.group))
+        return (key in store and isinstance(store.f[key], adios.group))
 
     @property
     def _names(self):
@@ -197,16 +186,11 @@ class ADIOSGroup(compass_model.Container):
 
     def __iter__(self):
         for name in self._names:
-            if six.PY2:
-                yield self.store[pp.join(self._key, name).encode("ascii")]
-            else:
-                yield self.store[pp.join(self._key, name)]
+            yield self.store[pp.join(self._key, name)]
 
     def __getitem__(self, idx):
         name = self._names[idx]
         key = op.join(self._key, name)
-        if six.PY2:
-            key = key.encode('ascii')
         return self._store[key]
 
 
@@ -217,16 +201,11 @@ class ADIOSDataset(compass_model.Array):
 
     @staticmethod
     def can_handle(store, key):
-        if six.PY2:
-            return key in store and isinstance(store.f[key.encode("ascii")], adios.var)
-        else:
-            return key in store and isinstance(store.f[key], adios.var)
+        return key in store and isinstance(store.f[key], adios.var)
 
     def __init__(self, store, key):
         self._store = store
         self._key = key
-        if six.PY2:
-            key = key.encode('ascii')
         self._dset = store.f[key]
 
     @property
@@ -273,8 +252,6 @@ class ADIOSText(compass_model.Text):
 
     @staticmethod
     def can_handle(store, key):
-        if six.PY2:
-            key = key.encode("ascii")
         if key in store and isinstance(store.f[key], adios.var):
             if store.f[key].dtype.kind == 'S':
                 logger.debug("ASCII String (characters: %d)" % DATA[key].dtype.itemsize)
@@ -287,8 +264,6 @@ class ADIOSText(compass_model.Text):
     def __init__(self, store, key):
         self._store = store
         self._key = key
-        if six.PY2:
-            key = key.encode("ascii")
         self.data = store.f[key]
 
     @property
@@ -323,8 +298,6 @@ class ADIOSKV(compass_model.KeyValue):
 
     def __init__(self, store, key):
         self._store = store
-        if six.PY2:
-            key = key.encode("ascii")
         self._obj = store.f[key]
         if (not key.startswith("/")) and key != "":
             key = "/%s" % key
@@ -353,8 +326,6 @@ class ADIOSKV(compass_model.KeyValue):
         return self._names
 
     def __getitem__(self, name):
-        if six.PY2:
-            name = name.encode("ascii")
         a = self._obj.attrs[name]
         return a.value
 


### PR DESCRIPTION
Adds Python 3 support to the ADIOS backend and enables it in testing again.

Related to #186