### PR TITLE
ADIOS: Install from Conda-Forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,12 @@ os:
   - osx
 
 env:
-  global:
-    - ADIOS_ROOT: $HOME/.cache/adios
   matrix:
     - PYTHON_VERSION=3.6
 
 cache:
   apt: true
   brew: true
-  directories:
-    - $HOME/.cache/adios
 
 before_install:
   # Set the anaconda environment
@@ -49,31 +45,16 @@ before_install:
   - source activate test-environment
 
 install:
-  # ADIOS C library
-  - export LD_LIBRARY_PATH=$ADIOS_ROOT/lib:$LD_LIBRARY_PATH
-  - export PATH=$ADIOS_ROOT/bin:$PATH
-  - ADIOS_FOUND=$(which adios_config >/dev/null && { echo 0; } || { echo 1; })
-  - if [ $ADIOS_FOUND -ne 0 ]; then
-      mkdir -p $ADIOS_ROOT &&
-      travis_retry git clone --depth=50 --branch=v1.13.0 https://github.com/ornladios/ADIOS.git $ADIOS_ROOT/src &&
-      cd $ADIOS_ROOT/src &&
-      ./autogen.sh &&
-      CFLAGS="-fPIC -g" ./configure --enable-static --disable-shared --prefix=$ADIOS_ROOT --with-mxml=/usr --with-zlib=/usr --disable-fortran --without-mpi &&
-      make && make install &&
-      cd - &&
-      rm -rf $ADIOS_ROOT/src;
-    fi
-  # other libraries
+  # libraries from conda-forge
   - conda config --add channels conda-forge
   # python packages
-  - conda install -q h5py lxml numpy matplotlib pydap requests shapely proj4 geos cartopy setuptools gdal
+  - conda install -q adios-python h5py lxml numpy matplotlib pydap requests shapely proj4 geos cartopy setuptools gdal
   - pip install --no-deps hyo2.bag
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         pip install wxPython;
     else
         pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython;
     fi
-  - pip install --no-deps 'git+https://github.com/ornladios/ADIOS.git@v1.13.0#egg=adios&subdirectory=wrappers/numpy'
   - pip install --no-deps -e .
 
 script:


### PR DESCRIPTION
Install ADIOS Python bindings from Conda-Forge on Travis-CI. Simplifies our scripts.

~~This PR is currently blocked by the `hyo.bag` install bug in #196 on OSX.~~ Weird, seems to work here but not in my local branch.

Ready to merge!